### PR TITLE
clang-3.6: provide path to gcc on Linux

### DIFF
--- a/pkgs/development/compilers/llvm/3.6/clang.nix
+++ b/pkgs/development/compilers/llvm/3.6/clang.nix
@@ -1,6 +1,8 @@
 { stdenv, fetch, cmake, libxml2, libedit, llvm, version, clang-tools-extra_src }:
 
-stdenv.mkDerivation {
+let
+  gcc = if stdenv.cc.cc.isGNU or false then stdenv.cc.cc else stdenv.cc.cc.gcc;
+in stdenv.mkDerivation {
   name = "clang-${version}";
 
   unpackPhase = ''
@@ -17,6 +19,8 @@ stdenv.mkDerivation {
     "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_CXX_FLAGS=-std=c++11"
   ] ++
+  # Maybe with compiler-rt this won't be needed?
+  (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
   (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
 
   patches = [ ./clang-purity.patch ./clang-exports.patch ];
@@ -35,6 +39,10 @@ stdenv.mkDerivation {
   '';
 
   enableParallelBuilding = true;
+
+  passthru = stdenv.lib.optionalAttrs stdenv.isLinux {
+    inherit gcc;
+  };
 
   meta = {
     description = "A c, c++, objective-c, and objective-c++ frontend for the llvm compiler";


### PR DESCRIPTION
gcc contains core runtime bits that aren't available elsewhere for Linux.

Refs #6449
